### PR TITLE
Add wellness_monitor microservice

### DIFF
--- a/go-to-gym-platform/backend/services/wellness_monitor/README.md
+++ b/go-to-gym-platform/backend/services/wellness_monitor/README.md
@@ -1,0 +1,15 @@
+# wellness_monitor
+
+Microservicio en Django 5.2 para almacenar métricas de salud provenientes de dispositivos wearables.
+
+## Endpoints
+- `POST /api/metrics/upload/` – Registrar una métrica.
+- `GET /api/metrics/` – Consultar métricas filtradas por `metric_type`, `start` y `end`.
+
+Todos los endpoints están protegidos con autenticación JWT.
+
+## Instalación rápida
+```bash
+pip install django djangorestframework djangorestframework-simplejwt django-cors-headers psycopg2-binary
+python manage.py migrate
+```

--- a/go-to-gym-platform/backend/services/wellness_monitor/manage.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/manage.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+
+def main():
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wellness_monitor.settings')
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/go-to-gym-platform/backend/services/wellness_monitor/monitor/__init__.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/monitor/__init__.py
@@ -1,0 +1,1 @@
+default_app_config='monitor.apps.MonitorConfig'

--- a/go-to-gym-platform/backend/services/wellness_monitor/monitor/apps.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/monitor/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class MonitorConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'monitor'

--- a/go-to-gym-platform/backend/services/wellness_monitor/monitor/models.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/monitor/models.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.db import models
+
+
+class HealthMetric(models.Model):
+    class Sources(models.TextChoices):
+        GOOGLE_FIT = 'GoogleFit', 'Google Fit'
+        APPLE_HEALTH = 'AppleHealth', 'Apple Health'
+        SAMSUNG_HEALTH = 'SamsungHealth', 'Samsung Health'
+
+    class MetricTypes(models.TextChoices):
+        STEPS = 'steps', 'Steps'
+        HEART_RATE = 'heart_rate', 'Heart Rate'
+        SLEEP = 'sleep', 'Sleep'
+        CALORIES = 'calories', 'Calories'
+        OTHER = 'other', 'Other'
+
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    source = models.CharField(max_length=32, choices=Sources.choices)
+    metric_type = models.CharField(max_length=32, choices=MetricTypes.choices)
+    value = models.FloatField()
+    timestamp = models.DateTimeField()
+
+    def __str__(self):
+        return f"{self.user} {self.metric_type} {self.value}"

--- a/go-to-gym-platform/backend/services/wellness_monitor/monitor/serializers.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/monitor/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+from .models import HealthMetric
+
+
+class HealthMetricSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = HealthMetric
+        fields = ['id', 'user', 'source', 'metric_type', 'value', 'timestamp']
+        read_only_fields = ['id']

--- a/go-to-gym-platform/backend/services/wellness_monitor/monitor/services.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/monitor/services.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from .models import HealthMetric
+
+
+def get_metrics(user, metric_type=None, start: datetime | None = None, end: datetime | None = None):
+    """Return metrics for a user filtered by type and date range."""
+    qs = HealthMetric.objects.filter(user=user)
+    if metric_type:
+        qs = qs.filter(metric_type=metric_type)
+    if start:
+        qs = qs.filter(timestamp__gte=start)
+    if end:
+        qs = qs.filter(timestamp__lte=end)
+    return qs.order_by('timestamp')

--- a/go-to-gym-platform/backend/services/wellness_monitor/monitor/urls.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/monitor/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from .views import UploadMetricView, MetricListView
+
+urlpatterns = [
+    path('metrics/upload/', UploadMetricView.as_view(), name='upload-metric'),
+    path('metrics/', MetricListView.as_view(), name='metric-list'),
+]

--- a/go-to-gym-platform/backend/services/wellness_monitor/monitor/views.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/monitor/views.py
@@ -1,0 +1,37 @@
+from rest_framework import generics, permissions
+from rest_framework.response import Response
+from rest_framework import status
+from django.contrib.auth import get_user_model
+from datetime import datetime
+
+from .models import HealthMetric
+from .serializers import HealthMetricSerializer
+from .services import get_metrics
+
+
+class UploadMetricView(generics.CreateAPIView):
+    queryset = HealthMetric.objects.all()
+    serializer_class = HealthMetricSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def perform_create(self, serializer):
+        if serializer.validated_data['user'].id != self.request.user.id:
+            raise permissions.PermissionDenied('Cannot upload metrics for another user')
+        serializer.save()
+
+
+class MetricListView(generics.ListAPIView):
+    serializer_class = HealthMetricSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        metric_type = self.request.query_params.get('metric_type')
+        start = self.request.query_params.get('start')
+        end = self.request.query_params.get('end')
+        start_dt = None
+        end_dt = None
+        if start:
+            start_dt = datetime.fromisoformat(start)
+        if end:
+            end_dt = datetime.fromisoformat(end)
+        return get_metrics(self.request.user, metric_type=metric_type, start=start_dt, end=end_dt)

--- a/go-to-gym-platform/backend/services/wellness_monitor/wellness_monitor/asgi.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/wellness_monitor/asgi.py
@@ -1,0 +1,6 @@
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wellness_monitor.settings')
+
+application = get_asgi_application()

--- a/go-to-gym-platform/backend/services/wellness_monitor/wellness_monitor/settings.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/wellness_monitor/settings.py
@@ -1,0 +1,90 @@
+import os
+from pathlib import Path
+from datetime import timedelta
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'change-me')
+DEBUG = os.environ.get('DEBUG', 'true').lower() == 'true'
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '*').split(',')
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'corsheaders',
+    'rest_framework',
+    'rest_framework_simplejwt',
+    'monitor',
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+ROOT_URLCONF = 'wellness_monitor.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = 'wellness_monitor.wsgi.application'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.environ.get('POSTGRES_DB', 'gotogym'),
+        'USER': os.environ.get('POSTGRES_USER', 'gotogym'),
+        'PASSWORD': os.environ.get('POSTGRES_PASSWORD', 'gotogym'),
+        'HOST': os.environ.get('POSTGRES_HOST', 'localhost'),
+        'PORT': os.environ.get('POSTGRES_PORT', '5432'),
+    }
+}
+
+AUTH_PASSWORD_VALIDATORS = []
+
+LANGUAGE_CODE = 'en-us'
+TIME_ZONE = 'UTC'
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = 'static/'
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CORS_ALLOW_ALL_ORIGINS = True
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
+}
+
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=60),
+}

--- a/go-to-gym-platform/backend/services/wellness_monitor/wellness_monitor/urls.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/wellness_monitor/urls.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from django.urls import path, include
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('api/', include('monitor.urls')),
+]

--- a/go-to-gym-platform/backend/services/wellness_monitor/wellness_monitor/wsgi.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/wellness_monitor/wsgi.py
@@ -1,0 +1,6 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wellness_monitor.settings')
+
+application = get_wsgi_application()

--- a/go-to-gym-platform/docs/wellness_monitor_examples.md
+++ b/go-to-gym-platform/docs/wellness_monitor_examples.md
@@ -1,0 +1,63 @@
+# Ejemplos de Consumo del Microservicio `wellness_monitor`
+
+A continuación se muestran ejemplos de cómo las apps móviles pueden enviar métricas de salud al endpoint `/api/metrics/upload/` protegido con JWT.
+
+## Google Fit (PWA / JavaScript)
+```javascript
+async function sendMetric(token, metric) {
+  await fetch('https://your-domain.com/api/metrics/upload/', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(metric)
+  });
+}
+
+// Ejemplo de métrica obtenida con OAuth de Google Fit
+sendMetric(jwtToken, {
+  user: 1,
+  source: 'GoogleFit',
+  metric_type: 'steps',
+  value: 1200,
+  timestamp: new Date().toISOString()
+});
+```
+
+## Apple Health (Swift)
+```swift
+let url = URL(string: "https://your-domain.com/api/metrics/upload/")!
+var request = URLRequest(url: url)
+request.httpMethod = "POST"
+request.addValue("Bearer \(jwtToken)", forHTTPHeaderField: "Authorization")
+request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+let payload: [String: Any] = [
+    "user": userId,
+    "source": "AppleHealth",
+    "metric_type": "heart_rate",
+    "value": 82,
+    "timestamp": ISO8601DateFormatter().string(from: Date())
+]
+request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+
+URLSession.shared.dataTask(with: request).resume()
+```
+
+## Samsung Health (Android Kotlin con Retrofit)
+```kotlin
+interface ApiService {
+    @POST("api/metrics/upload/")
+    suspend fun upload(@Body metric: MetricDto, @Header("Authorization") token: String)
+}
+
+val metric = MetricDto(
+    user = userId,
+    source = "SamsungHealth",
+    metric_type = "sleep",
+    value = 7.5f,
+    timestamp = Instant.now().toString()
+)
+apiService.upload(metric, "Bearer $jwtToken")
+```


### PR DESCRIPTION
## Summary
- implement Django microservice `wellness_monitor` under `backend/services`
- add `HealthMetric` model and REST API to upload/query metrics protected by JWT
- document example requests from Google Fit, Apple Health and Samsung Health

## Testing
- `python3 -m py_compile backend/services/wellness_monitor/manage.py backend/services/wellness_monitor/wellness_monitor/*.py backend/services/wellness_monitor/monitor/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6848b3127bbc8332b51c9179f59937cb