### PR TITLE
Add influencer marketing app skeleton

### DIFF
--- a/go-to-gym-platform/backend/core_api/influencer/models.py
+++ b/go-to-gym-platform/backend/core_api/influencer/models.py
@@ -1,0 +1,33 @@
+"""Influencer app models for referral tracking."""
+from django.db import models
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+class InfluencerProfile(models.Model):
+    """Stores influencer metrics and wallet info for a user."""
+
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="influencer_profile")
+    referral_code = models.CharField(max_length=50, unique=True)
+    total_referred_users = models.PositiveIntegerField(default=0)
+    total_sales_value = models.FloatField(default=0.0)
+    commission_earned = models.FloatField(default=0.0)
+    wallet_balance = models.FloatField(default=0.0)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self) -> str:
+        return f"{self.user} - {self.referral_code}"
+
+
+class ReferralTransaction(models.Model):
+    """Represents a single referred sale processed through the platform."""
+
+    influencer = models.ForeignKey(InfluencerProfile, on_delete=models.CASCADE, related_name="transactions")
+    referred_user = models.ForeignKey(User, null=True, blank=True, on_delete=models.SET_NULL)
+    sale_amount = models.FloatField()
+    commission_amount = models.FloatField()
+    timestamp = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self) -> str:
+        return f"{self.influencer.referral_code}: {self.sale_amount}"

--- a/go-to-gym-platform/backend/core_api/influencer/serializers.py
+++ b/go-to-gym-platform/backend/core_api/influencer/serializers.py
@@ -1,0 +1,18 @@
+"""Serializers for influencer API."""
+from rest_framework import serializers
+
+from .models import InfluencerProfile
+
+
+class InfluencerStatsSerializer(serializers.ModelSerializer):
+    """Serializer used by the optional stats API."""
+
+    class Meta:
+        model = InfluencerProfile
+        fields = [
+            "referral_code",
+            "total_referred_users",
+            "total_sales_value",
+            "commission_earned",
+            "wallet_balance",
+        ]

--- a/go-to-gym-platform/backend/core_api/influencer/templates/influencer/dashboard.html
+++ b/go-to-gym-platform/backend/core_api/influencer/templates/influencer/dashboard.html
@@ -1,0 +1,31 @@
+{# Dashboard para influencers. Modificar libremente en React o HTML. #}
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Influencer Dashboard</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <h1>Panel de Influencer</h1>
+    <p>Código de referido: {{ profile.referral_code }}</p>
+    <p>Enlace: https://gotogym.com/?ref={{ profile.referral_code }}</p>
+    <p>Usuarios referidos: {{ profile.total_referred_users }}</p>
+    <p>Comisión ganada: {{ profile.commission_earned }}</p>
+    <canvas id="salesChart" width="400" height="200"></canvas>
+    <button>Solicitar retiro</button>
+    <script>
+        const ctx = document.getElementById('salesChart');
+        new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: ['Ventas'],
+                datasets: [{
+                    label: 'Valor total',
+                    data: [{{ profile.total_sales_value }}],
+                    borderWidth: 1
+                }]
+            }
+        });
+    </script>
+</body>
+</html>

--- a/go-to-gym-platform/backend/core_api/influencer/templates/influencer/promo_material.html
+++ b/go-to-gym-platform/backend/core_api/influencer/templates/influencer/promo_material.html
@@ -1,0 +1,11 @@
+{# Descarga de material promocional. #}
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Material Promocional</title>
+</head>
+<body>
+    <h1>Descarga Material Promocional</h1>
+    <p>Aquí encontrarás banners e imágenes para compartir.</p>
+</body>
+</html>

--- a/go-to-gym-platform/backend/core_api/influencer/templates/influencer/referral_page.html
+++ b/go-to-gym-platform/backend/core_api/influencer/templates/influencer/referral_page.html
@@ -1,0 +1,12 @@
+{# Página pública de referido. #}
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Únete a GoToGym</title>
+</head>
+<body>
+    <h1>Bienvenido!</h1>
+    <p>Has sido invitado por el código {{ code }}.</p>
+    <a href="/register/">Regístrate aquí</a>
+</body>
+</html>

--- a/go-to-gym-platform/backend/core_api/influencer/urls.py
+++ b/go-to-gym-platform/backend/core_api/influencer/urls.py
@@ -1,0 +1,22 @@
+"""URL configuration for the influencer app."""
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path("dashboard/", views.dashboard, name="influencer_dashboard"),
+    path("promo/", views.promo_material, name="influencer_promo"),
+    path("referral/", views.referral_page, name="influencer_referral_page"),
+    path("payment/webhook/", views.payment_webhook, name="payment_webhook"),
+]
+
+# Optional API routes are added only if DRF is available
+try:
+    from rest_framework_simplejwt.views import TokenObtainPairView  # noqa: F401
+
+    urlpatterns += [
+        path("api/influencer/stats/", views.stats, name="api_influencer_stats"),
+        path("api/influencer/withdraw/", views.withdraw, name="api_influencer_withdraw"),
+    ]
+except Exception:
+    pass

--- a/go-to-gym-platform/backend/core_api/influencer/views.py
+++ b/go-to-gym-platform/backend/core_api/influencer/views.py
@@ -1,0 +1,87 @@
+"""Views for influencer marketing operations."""
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render, get_object_or_404
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+
+from .models import InfluencerProfile, ReferralTransaction
+
+
+@login_required
+def dashboard(request: HttpRequest) -> HttpResponse:
+    """Renders the influencer dashboard with metrics."""
+    profile = get_object_or_404(InfluencerProfile, user=request.user)
+    context = {
+        "profile": profile,
+    }
+    return render(request, "influencer/dashboard.html", context)
+
+
+def referral_page(request: HttpRequest) -> HttpResponse:
+    """Public page for a referral code."""
+    code = request.GET.get("ref")
+    context = {"code": code}
+    return render(request, "influencer/referral_page.html", context)
+
+
+@login_required
+def promo_material(request: HttpRequest) -> HttpResponse:
+    """Page to download marketing assets."""
+    return render(request, "influencer/promo_material.html")
+
+
+@csrf_exempt
+def payment_webhook(request: HttpRequest) -> HttpResponse:
+    """Webhook endpoint to record referred sales from MercadoPago."""
+    if request.method != "POST":
+        return JsonResponse({"detail": "Method not allowed"}, status=405)
+
+    ref_code = request.GET.get("ref")
+    if not ref_code:
+        return JsonResponse({"detail": "No referral code"}, status=400)
+
+    profile = get_object_or_404(InfluencerProfile, referral_code=ref_code)
+
+    # parse sale amount from MercadoPago payload (simplified)
+    data = request.POST
+    sale_amount = float(data.get("sale_amount", 0))
+    commission_amount = sale_amount * 0.1  # 10% commission example
+
+    ReferralTransaction.objects.create(
+        influencer=profile,
+        sale_amount=sale_amount,
+        commission_amount=commission_amount,
+    )
+
+    profile.total_referred_users = profile.transactions.count()
+    profile.total_sales_value += sale_amount
+    profile.commission_earned += commission_amount
+    profile.wallet_balance += commission_amount
+    profile.save(update_fields=[
+        "total_referred_users",
+        "total_sales_value",
+        "commission_earned",
+        "wallet_balance",
+    ])
+
+    return JsonResponse({"detail": "Transaction recorded"})
+
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from .serializers import InfluencerStatsSerializer
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def stats(request):
+    """Return influencer statistics in JSON format."""
+    serializer = InfluencerStatsSerializer(request.user.influencer_profile)
+    return Response(serializer.data)
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def withdraw(request):
+    """Endpoint to request a wallet withdrawal (placeholder)."""
+    return Response({"detail": "Withdrawal requested"})


### PR DESCRIPTION
## Summary
- create `influencer` app skeleton under `backend/core_api`
- implement `InfluencerProfile` and `ReferralTransaction` models
- add login protected dashboard, webhook and promo material views
- provide optional DRF API endpoints
- include simple HTML templates for dashboard, referral page and promo material

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848b463f2088332872923c6e10ed66d