### PR TITLE
Add basic PWA setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # GoToGtymPrime
 GoToGym Prime es el servicio al Cliente de la Marca GoToGym Sportwear as a Service
+
+This repository now includes a minimal Next.js PWA setup under `go-to-gym-platform/frontend/webapp`.

--- a/go-to-gym-platform/README.md
+++ b/go-to-gym-platform/README.md
@@ -1,3 +1,5 @@
 # Go-To-Gym Platform
 
 Este directorio contiene la arquitectura modular de GoToGym. Se divide en distintos paquetes para frontend, backend, microservicios de IA, integraciones y herramientas de infraestructura. Consulta el documento [docs/tech-stack.md](docs/tech-stack.md) para ver la lista detallada de tecnologías y dependencias sugeridas.
+
+La carpeta `frontend/webapp` ahora contiene una configuracion basica de Next.js con soporte para PWA usando `next-pwa`.

--- a/go-to-gym-platform/frontend/webapp/next.config.js
+++ b/go-to-gym-platform/frontend/webapp/next.config.js
@@ -1,0 +1,8 @@
+const withPWA = require('next-pwa')({
+  dest: 'public',
+  disable: process.env.NODE_ENV === 'development',
+});
+
+module.exports = withPWA({
+  reactStrictMode: true,
+});

--- a/go-to-gym-platform/frontend/webapp/package.json
+++ b/go-to-gym-platform/frontend/webapp/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "gotogym-webapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.13",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-pwa": "^5.6.0"
+  }
+}

--- a/go-to-gym-platform/frontend/webapp/pages/_app.js
+++ b/go-to-gym-platform/frontend/webapp/pages/_app.js
@@ -1,0 +1,7 @@
+import '../styles/globals.css';
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;

--- a/go-to-gym-platform/frontend/webapp/pages/_document.js
+++ b/go-to-gym-platform/frontend/webapp/pages/_document.js
@@ -1,0 +1,17 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html lang="es">
+      <Head>
+        <link rel="manifest" href="/manifest.json" />
+        <link rel="apple-touch-icon" href="/icons/icon-512x512.svg" />
+        <meta name="theme-color" content="#ffffff" />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/go-to-gym-platform/frontend/webapp/pages/index.js
+++ b/go-to-gym-platform/frontend/webapp/pages/index.js
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <h1>GoToGym PWA</h1>
+    </main>
+  );
+}

--- a/go-to-gym-platform/frontend/webapp/public/icons/icon-192x192.svg
+++ b/go-to-gym-platform/frontend/webapp/public/icons/icon-192x192.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192">
+  <rect width="192" height="192" rx="24" ry="24" fill="#0070f3"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#ffffff" font-size="72">G</text>
+</svg>

--- a/go-to-gym-platform/frontend/webapp/public/icons/icon-512x512.svg
+++ b/go-to-gym-platform/frontend/webapp/public/icons/icon-512x512.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512">
+  <rect width="512" height="512" rx="64" ry="64" fill="#0070f3"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#ffffff" font-size="200">G</text>
+</svg>

--- a/go-to-gym-platform/frontend/webapp/public/manifest.json
+++ b/go-to-gym-platform/frontend/webapp/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "GoToGym",
+  "short_name": "GoToGym",
+  "icons": [
+    {
+      "src": "/icons/icon-192x192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icons/icon-512x512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "start_url": "/",
+  "display": "standalone"
+}

--- a/go-to-gym-platform/frontend/webapp/styles/globals.css
+++ b/go-to-gym-platform/frontend/webapp/styles/globals.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+}


### PR DESCRIPTION
## Summary
- add minimal Next.js project for the frontend webapp
- configure next-pwa with service worker and manifest
- replace binary PWA icons with lightweight SVG files
- mention PWA setup in README files

## Testing
- `npm test --silent` *(no test script, nothing ran)*
- `python -m pytest -q` *(no tests were collected)*

------
https://chatgpt.com/codex/tasks/task_e_6848b2aa97c88332b073cceefdec77d4