### PR TITLE
Add requirements file and update backend setup

### DIFF
--- a/go-to-gym-platform/backend/services/wellness_monitor/README.md
+++ b/go-to-gym-platform/backend/services/wellness_monitor/README.md
@@ -10,6 +10,6 @@ Todos los endpoints están protegidos con autenticación JWT.
 
 ## Instalación rápida
 ```bash
-pip install django djangorestframework djangorestframework-simplejwt django-cors-headers psycopg2-binary
+pip install -r ../../../../requirements.txt
 python manage.py migrate
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+Django>=5.2
+wagtail>=6.0
+django-crispy-forms
+crispy-tailwind
+django-widget-tweaks
+django-taggit
+django-modelcluster
+Pillow
+mysqlclient
+djangorestframework
+djangorestframework-simplejwt
+django-cors-headers
+psycopg2-binary


### PR DESCRIPTION
## Summary
- document backend dependencies in `requirements.txt`
- reference the file in wellness_monitor setup instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848b5df0b408332924e6ffa008451a3