### PR TITLE
Add public HTML templates

### DIFF
--- a/go-to-gym-platform/frontend/webapp/templates/public_pages/about_us.html
+++ b/go-to-gym-platform/frontend/webapp/templates/public_pages/about_us.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>¿Quiénes somos?</title>
+    <!-- Estilos personalizados -->
+</head>
+<body>
+    <!-- Aquí va el menú -->
+
+    <main>
+        <h1>¿Quiénes somos?</h1>
+        <!-- Contenido principal -->
+        <section>
+            <p>Nuestra historia y la misión de la marca. Visión de futuro y equipo fundador.</p>
+        </section>
+    </main>
+
+    <!-- Aquí va el footer -->
+    <!-- Scripts adicionales -->
+</body>
+</html>

--- a/go-to-gym-platform/frontend/webapp/templates/public_pages/contact_us.html
+++ b/go-to-gym-platform/frontend/webapp/templates/public_pages/contact_us.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Contáctanos</title>
+    <!-- Estilos personalizados -->
+</head>
+<body>
+    <!-- Aquí va el menú -->
+
+    <main>
+        <h1>Contáctanos</h1>
+        <!-- Contenido principal -->
+        <section>
+            <form>
+                <label>Nombre:
+                    <input type="text" name="nombre" required>
+                </label>
+                <label>Email:
+                    <input type="email" name="email" required>
+                </label>
+                <label>Asunto:
+                    <input type="text" name="asunto" required>
+                </label>
+                <label>Mensaje:
+                    <textarea name="mensaje" required></textarea>
+                </label>
+                <button type="submit">Enviar</button>
+            </form>
+            <!-- Opcional: mapa de ubicación -->
+        </section>
+    </main>
+
+    <!-- Aquí va el footer -->
+    <!-- Scripts adicionales -->
+</body>
+</html>

--- a/go-to-gym-platform/frontend/webapp/templates/public_pages/investors.html
+++ b/go-to-gym-platform/frontend/webapp/templates/public_pages/investors.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Información para Inversionistas</title>
+    <!-- Estilos personalizados -->
+</head>
+<body>
+    <!-- Aquí va el menú -->
+
+    <main>
+        <h1>Información para Inversionistas</h1>
+        <!-- Contenido principal -->
+        <section>
+            <p>Resumen de nuestro modelo de negocio, métricas clave y proyecciones. Para contacto comercial escríbenos.</p>
+        </section>
+    </main>
+
+    <!-- Aquí va el footer -->
+    <!-- Scripts adicionales -->
+</body>
+</html>

--- a/go-to-gym-platform/frontend/webapp/templates/public_pages/pqr.html
+++ b/go-to-gym-platform/frontend/webapp/templates/public_pages/pqr.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>PQR - Peticiones, Quejas y Reclamos</title>
+    <!-- Estilos personalizados -->
+</head>
+<body>
+    <!-- Aquí va el menú -->
+
+    <main>
+        <h1>PQR - Peticiones, Quejas y Reclamos</h1>
+        <!-- Contenido principal -->
+        <section>
+            <form>
+                <!-- Campo nombre -->
+                <label>Nombre:
+                    <input type="text" name="nombre" required>
+                </label>
+                <!-- Campo email -->
+                <label>Email:
+                    <input type="email" name="email" required>
+                </label>
+                <!-- Tipo de solicitud -->
+                <label>Tipo de solicitud:
+                    <select name="tipo">
+                        <option value="peticion">Petición</option>
+                        <option value="queja">Queja</option>
+                        <option value="reclamo">Reclamo</option>
+                    </select>
+                </label>
+                <!-- Mensaje -->
+                <label>Mensaje:
+                    <textarea name="mensaje" required></textarea>
+                </label>
+                <!-- Botón de envío -->
+                <button type="submit">Enviar</button>
+            </form>
+        </section>
+    </main>
+
+    <!-- Aquí va el footer -->
+    <!-- Scripts adicionales -->
+</body>
+</html>

--- a/go-to-gym-platform/frontend/webapp/templates/public_pages/prime_plans.html
+++ b/go-to-gym-platform/frontend/webapp/templates/public_pages/prime_plans.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Planes GoToGym Prime</title>
+    <!-- Estilos personalizados -->
+</head>
+<body>
+    <!-- Aquí va el menú -->
+
+    <main>
+        <h1>Planes GoToGym Prime</h1>
+        <!-- Contenido principal -->
+        <section>
+            <ul>
+                <li>Gratuito - Acceso limitado</li>
+                <li>Mensual - Acceso completo por 30 días</li>
+                <li>Anual - Beneficios exclusivos todo el año</li>
+            </ul>
+            <!-- Botón de compra -->
+            <button>Comprar Plan</button>
+        </section>
+    </main>
+
+    <!-- Aquí va el footer -->
+    <!-- Scripts adicionales -->
+</body>
+</html>

--- a/go-to-gym-platform/frontend/webapp/templates/public_pages/privacy_policy.html
+++ b/go-to-gym-platform/frontend/webapp/templates/public_pages/privacy_policy.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Política de Privacidad</title>
+    <!-- Estilos personalizados -->
+</head>
+<body>
+    <!-- Aquí va el menú -->
+
+    <main>
+        <h1>Política de Privacidad</h1>
+        <!-- Contenido principal -->
+        <section>
+            <p>Información sobre tratamiento de datos personales, uso de cookies y consentimiento informado. Para más detalles contacta al DPO.</p>
+        </section>
+    </main>
+
+    <!-- Aquí va el footer -->
+    <!-- Scripts adicionales -->
+</body>
+</html>

--- a/go-to-gym-platform/frontend/webapp/templates/public_pages/terms_and_conditions.html
+++ b/go-to-gym-platform/frontend/webapp/templates/public_pages/terms_and_conditions.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Términos y Condiciones</title>
+    <!-- Estilos personalizados -->
+</head>
+<body>
+    <!-- Aquí va el menú -->
+
+    <main>
+        <h1>Términos y Condiciones</h1>
+        <!-- Contenido principal -->
+        <section>
+            <p>Estas son las cláusulas básicas de uso, responsabilidades y propiedad intelectual. Al utilizar este sitio aceptas los términos.</p>
+        </section>
+    </main>
+
+    <!-- Aquí va el footer -->
+    <!-- Scripts adicionales -->
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add placeholder static pages for institutional, legal, and commercial info

## Testing
- `pytest -q`
- `python gotogym/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6848b7436784833290f57c37174dc646