### PR TITLE
Add minimal PWA pages

### DIFF
--- a/go-to-gym-platform/frontend/webapp/pages/login.js
+++ b/go-to-gym-platform/frontend/webapp/pages/login.js
@@ -1,0 +1,12 @@
+export default function Login() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center">
+      <h1>Iniciar Sesión</h1>
+      <form className="flex flex-col gap-2 mt-4">
+        <input type="text" placeholder="Usuario" required />
+        <input type="password" placeholder="Contraseña" required />
+        <button type="submit">Ingresar</button>
+      </form>
+    </main>
+  );
+}

--- a/go-to-gym-platform/frontend/webapp/pages/settings.js
+++ b/go-to-gym-platform/frontend/webapp/pages/settings.js
@@ -1,0 +1,8 @@
+export default function Settings() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center">
+      <h1>Configuraciones</h1>
+      <p>Aquí podrás ajustar tus preferencias.</p>
+    </main>
+  );
+}

--- a/go-to-gym-platform/frontend/webapp/pages/welcome.js
+++ b/go-to-gym-platform/frontend/webapp/pages/welcome.js
@@ -1,0 +1,7 @@
+export default function Welcome() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <h1>Bienvenido a GoToGym</h1>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add login, welcome and settings pages to the Next.js PWA
- pages provide basic placeholders for UI

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b804223883328cc4db7d35e12ec2