### PR TITLE
Implement post-quantum auth module

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.env
+.git
+/media
+/staticfiles

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . /app
+CMD ["python", "gotogym/manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  web:
+    build: .
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env

--- a/gotogym/auth/apps.py
+++ b/gotogym/auth/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class AuthConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'auth'

--- a/gotogym/auth/models.py
+++ b/gotogym/auth/models.py
@@ -1,0 +1,17 @@
+from django.contrib.auth.models import AbstractUser
+from django.db import models
+from django.utils import timezone
+
+class User(AbstractUser):
+    username = None
+    email = models.EmailField(unique=True)
+    full_name = models.CharField(max_length=150)
+    accepted_terms = models.BooleanField(default=False)
+    terms_accepted_at = models.DateTimeField(null=True, blank=True)
+    terms_hash = models.CharField(max_length=128, blank=True)
+
+    USERNAME_FIELD = 'email'
+    REQUIRED_FIELDS = []
+
+    def __str__(self):
+        return self.email

--- a/gotogym/auth/pqcrypto_utils.py
+++ b/gotogym/auth/pqcrypto_utils.py
@@ -1,0 +1,33 @@
+"""Post-quantum crypto helpers using python-oqs."""
+import base64
+from pathlib import Path
+
+import oqs
+
+SIG_ALG = "Dilithium2"
+
+_keypair_path = Path(__file__).resolve().parent / "pq_keys"
+_keypair_path.mkdir(exist_ok=True)
+_priv_file = _keypair_path / "private.key"
+_pub_file = _keypair_path / "public.key"
+
+if _priv_file.exists() and _pub_file.exists():
+    private_key = _priv_file.read_bytes()
+    public_key = _pub_file.read_bytes()
+else:
+    with oqs.Signature(SIG_ALG) as signer:
+        public_key = signer.generate_keypair()
+        private_key = signer.export_secret_key()
+    _priv_file.write_bytes(private_key)
+    _pub_file.write_bytes(public_key)
+
+def sign_message(message: bytes) -> str:
+    """Sign a message and return base64 signature."""
+    with oqs.Signature(SIG_ALG, secret_key=private_key) as signer:
+        signature = signer.sign(message)
+    return base64.b64encode(signature).decode()
+
+def verify_message(message: bytes, signature_b64: str) -> bool:
+    signature = base64.b64decode(signature_b64)
+    with oqs.Signature(SIG_ALG, public_key=public_key) as verifier:
+        return verifier.verify(message, signature)

--- a/gotogym/auth/serializers.py
+++ b/gotogym/auth/serializers.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import hashlib
+
+from django.contrib.auth import authenticate
+from django.contrib.auth.hashers import make_password
+from django.utils import timezone
+from rest_framework import serializers
+
+from .models import User
+
+class RegisterSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(write_only=True)
+    password2 = serializers.CharField(write_only=True)
+    accepted_terms = serializers.BooleanField(write_only=True)
+
+    class Meta:
+        model = User
+        fields = ("email", "full_name", "password", "password2", "accepted_terms")
+
+    def validate(self, data):
+        if data["password"] != data["password2"]:
+            raise serializers.ValidationError("Las contraseñas no coinciden")
+        if not data.get("accepted_terms"):
+            raise serializers.ValidationError(
+                "Debes aceptar los términos y condiciones para continuar"
+            )
+        return data
+
+    def create(self, validated_data):
+        validated_data.pop("password2")
+        terms_path = self.context.get("terms_path")
+        terms_text = Path(terms_path).read_text(encoding="utf-8")
+        terms_hash = hashlib.sha512(terms_text.encode()).hexdigest()
+        user = User.objects.create(
+            email=validated_data["email"],
+            full_name=validated_data["full_name"],
+            accepted_terms=True,
+            terms_accepted_at=timezone.now(),
+            terms_hash=terms_hash,
+            password=make_password(validated_data["password"]),
+        )
+        return user
+
+class LoginSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    password = serializers.CharField()
+
+    def validate(self, data):
+        user = authenticate(email=data.get("email"), password=data.get("password"))
+        if not user:
+            raise serializers.ValidationError("Credenciales incorrectas")
+        data["user"] = user
+        return data

--- a/gotogym/auth/urls.py
+++ b/gotogym/auth/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from .views import RegisterView, LoginView
+
+urlpatterns = [
+    path('auth/register/', RegisterView.as_view(), name='api_register'),
+    path('auth/login/', LoginView.as_view(), name='api_login'),
+]

--- a/gotogym/auth/views.py
+++ b/gotogym/auth/views.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+from django.conf import settings
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from .serializers import RegisterSerializer, LoginSerializer
+from .pqcrypto_utils import sign_message
+
+TERMS_PATH = Path(settings.BASE_DIR) / 'gotogym' / 'templates' / 'auth' / 'terms_and_conditions.html'
+
+class RegisterView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        serializer = RegisterSerializer(data=request.data, context={'terms_path': TERMS_PATH})
+        if serializer.is_valid():
+            user = serializer.save()
+            return Response({'detail': 'Registro exitoso'}, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+class LoginView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        serializer = LoginSerializer(data=request.data)
+        if serializer.is_valid():
+            user = serializer.validated_data['user']
+            refresh = RefreshToken.for_user(user)
+            access = str(refresh.access_token)
+            signature = sign_message(access.encode())
+            return Response({
+                'access': access,
+                'refresh': str(refresh),
+                'signature': signature,
+            })
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/gotogym/gotogym/settings.py
+++ b/gotogym/gotogym/settings.py
@@ -53,6 +53,10 @@ INSTALLED_APPS = [
     'gestion',
     'users',
     'blog',
+    'rest_framework',
+    'rest_framework_simplejwt',
+    'corsheaders',
+    'auth',
     'cart',
     'store',
     'crispy_forms',
@@ -66,6 +70,7 @@ CRISPY_TEMPLATE_PACK = "tailwind"
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     "django.middleware.locale.LocaleMiddleware",
     'django.middleware.common.CommonMiddleware',
@@ -180,5 +185,13 @@ STATICFILES_DIRS = [
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 WAGTAILADMIN_BASE_URL = os.getenv(
     "WAGTAILADMIN_BASE_URL",
-    "http://localhost:8000"  
+    "http://localhost:8000"
 )
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    )
+}
+
+AUTH_USER_MODEL = 'auth.User'

--- a/gotogym/gotogym/templates/auth/login.html
+++ b/gotogym/gotogym/templates/auth/login.html
@@ -1,0 +1,7 @@
+<!-- Frontend may replace styles/scripts here -->
+<form method="post" action="/auth/login/">
+    <!-- csrf token -->
+    <input type="email" name="email" placeholder="Email" required />
+    <input type="password" name="password" placeholder="Contraseña" required />
+    <button type="submit">Iniciar sesión</button>
+</form>

--- a/gotogym/gotogym/templates/auth/register.html
+++ b/gotogym/gotogym/templates/auth/register.html
@@ -1,0 +1,12 @@
+<!-- Editable register form -->
+<form method="post" action="/auth/register/">
+    <!-- csrf token -->
+    <input type="text" name="full_name" placeholder="Nombre completo" required />
+    <input type="email" name="email" placeholder="Email" required />
+    <input type="password" name="password" placeholder="Contraseña" required />
+    <input type="password" name="password2" placeholder="Repite contraseña" required />
+    <label>
+        <input type="checkbox" name="accepted_terms" required /> Acepto los términos
+    </label>
+    <button type="submit">Registrarme</button>
+</form>

--- a/gotogym/gotogym/templates/auth/success_register.html
+++ b/gotogym/gotogym/templates/auth/success_register.html
@@ -1,0 +1,2 @@
+<!-- Mensaje editable para confirmar registro -->
+<p>Usuario registrado correctamente.</p>

--- a/gotogym/gotogym/templates/auth/terms_and_conditions.html
+++ b/gotogym/gotogym/templates/auth/terms_and_conditions.html
@@ -1,0 +1,2 @@
+<!-- Términos y condiciones modificables por el equipo frontend -->
+<p>Aquí van los términos y condiciones de uso.</p>

--- a/gotogym/gotogym/urls.py
+++ b/gotogym/gotogym/urls.py
@@ -21,6 +21,7 @@ urlpatterns += i18n_patterns(
     path('gestion/',   include('gestion.urls')),
     path('',           include('users.urls')),
     path('blog/', include('blog.urls', namespace='blog')),
+    path('api/', include('auth.urls')),
     path('dashboard/', include(('dashboard.urls', 'dashboard'), namespace='dashboard')),
     path('cart/',      include(('cart.urls', 'cart'),          namespace='cart')),
     path('tienda/',    include(('store.urls', 'store'),        namespace='store')),

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ djangorestframework
 djangorestframework-simplejwt
 django-cors-headers
 psycopg2-binary
+
+python-oqs
+cryptography>=42.0.0


### PR DESCRIPTION
## Summary
- add python-oqs and cryptography to requirements
- create auth app with custom User model and JWT endpoints
- add post-quantum signing utilities
- create login/registration templates under templates/auth
- add Dockerfile and docker-compose for local setup
- update Django settings and urls

## Testing
- `python -m py_compile gotogym/auth/*.py`
- `python gotogym/manage.py makemigrations auth` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6848b9850b908332922262ef551ac9c6