### PR TITLE
Add metrics page and JWT endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
 # GoToGtymPrime
-GoToGym Prime es el servicio al Cliente de la Marca GoToGym Sportwear as a Service
+GoToGym Prime es el servicio al Cliente de la Marca GoToGym Sportwear as a Service.
 
-This repository now includes a minimal Next.js PWA setup under `go-to-gym-platform/frontend/webapp`.
+Este repositorio contiene un proyecto Django clásico (`gotogym`) y un nuevo
+esqueleto modular en `go-to-gym-platform` con frontend Next.js y microservicios.
+
+Para pruebas locales puedes iniciar el microservicio `wellness_monitor` en el
+puerto `8001` y el proyecto Django principal en `8000`:
+
+```bash
+python go-to-gym-platform/backend/services/wellness_monitor/manage.py migrate
+python go-to-gym-platform/backend/services/wellness_monitor/manage.py runserver 0.0.0.0:8001
+
+python gotogym/manage.py migrate
+python gotogym/manage.py runserver 0.0.0.0:8000
+```
+
+La aplicación PWA se encuentra en `go-to-gym-platform/frontend/webapp` y puede
+consultar las métricas del microservicio.

--- a/go-to-gym-platform/README.md
+++ b/go-to-gym-platform/README.md
@@ -2,4 +2,4 @@
 
 Este directorio contiene la arquitectura modular de GoToGym. Se divide en distintos paquetes para frontend, backend, microservicios de IA, integraciones y herramientas de infraestructura. Consulta el documento [docs/tech-stack.md](docs/tech-stack.md) para ver la lista detallada de tecnologías y dependencias sugeridas.
 
-La carpeta `frontend/webapp` ahora contiene una configuracion basica de Next.js con soporte para PWA usando `next-pwa`.
+La carpeta `frontend/webapp` ahora contiene una configuracion basica de Next.js con soporte para PWA usando `next-pwa`. Incluye una página `metrics` que consume el microservicio `wellness_monitor`.

--- a/go-to-gym-platform/backend/services/wellness_monitor/README.md
+++ b/go-to-gym-platform/backend/services/wellness_monitor/README.md
@@ -6,10 +6,12 @@ Microservicio en Django 5.2 para almacenar métricas de salud provenientes de di
 - `POST /api/metrics/upload/` – Registrar una métrica.
 - `GET /api/metrics/` – Consultar métricas filtradas por `metric_type`, `start` y `end`.
 
-Todos los endpoints están protegidos con autenticación JWT.
+Todos los endpoints están protegidos con autenticación JWT. Obtén un token enviando tus credenciales a `/api/token/`.
 
 ## Instalación rápida
 ```bash
 pip install -r ../../../../requirements.txt
 python manage.py migrate
+# Ejecutar en el puerto 8001
+python manage.py runserver 0.0.0.0:8001
 ```

--- a/go-to-gym-platform/backend/services/wellness_monitor/wellness_monitor/urls.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/wellness_monitor/urls.py
@@ -1,7 +1,10 @@
 from django.contrib import admin
 from django.urls import path, include
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('monitor.urls')),
+    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 ]

--- a/go-to-gym-platform/frontend/webapp/pages/metrics.js
+++ b/go-to-gym-platform/frontend/webapp/pages/metrics.js
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+export default function Metrics() {
+  const [metrics, setMetrics] = useState([]);
+
+  useEffect(() => {
+    async function fetchMetrics() {
+      try {
+        const token = localStorage.getItem('jwtToken');
+        if (!token) return;
+        const res = await fetch('http://localhost:8001/api/metrics/', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setMetrics(data);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchMetrics();
+  }, []);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center p-4">
+      <h1 className="text-xl mb-4">Métricas de Salud</h1>
+      <ul className="w-full max-w-md">
+        {metrics.map((m) => (
+          <li key={m.id} className="border-b py-2">
+            <span className="font-semibold">{m.metric_type}</span>: {m.value} ({new Date(m.timestamp).toLocaleString()})
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add JWT token endpoints to `wellness_monitor`
- document how to obtain a token and run the service
- document new Next.js metrics page in main README and platform README
- implement `metrics.js` page to fetch metrics

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django>=5.2)*
- `pytest -q` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6848ba759f8c8332ae1898b210b87cee