### PR TITLE
Implement notification email templates

### DIFF
--- a/go-to-gym-platform/README.md
+++ b/go-to-gym-platform/README.md
@@ -3,3 +3,8 @@
 Este directorio contiene la arquitectura modular de GoToGym. Se divide en distintos paquetes para frontend, backend, microservicios de IA, integraciones y herramientas de infraestructura. Consulta el documento [docs/tech-stack.md](docs/tech-stack.md) para ver la lista detallada de tecnologías y dependencias sugeridas.
 
 La carpeta `frontend/webapp` ahora contiene una configuracion basica de Next.js con soporte para PWA usando `next-pwa`.
+
+## Sistema de notificaciones
+
+Se añadió una app `notifications` en `backend/core_api` con modelos para registrar tokens de dispositivo y un historial de notificaciones. Incluye vistas protegidas con JWT para enviar y listar notificaciones. En el frontend se añadieron utilidades para registrar el token de FCM y un componente `NotificationBanner` que muestra los mensajes dentro de la PWA. El service worker `firebase-messaging-sw.js` permite recibir notificaciones en segundo plano.
+Se añadieron plantillas de ejemplo en `backend/core_api/notifications/templates/emails` para los correos de notificación.

--- a/go-to-gym-platform/backend/core_api/notifications/apps.py
+++ b/go-to-gym-platform/backend/core_api/notifications/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class NotificationsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'core_api.notifications'

--- a/go-to-gym-platform/backend/core_api/notifications/models.py
+++ b/go-to-gym-platform/backend/core_api/notifications/models.py
@@ -1,0 +1,28 @@
+from django.conf import settings
+from django.db import models
+
+
+class Notification(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    title = models.CharField(max_length=255)
+    body = models.TextField()
+    type = models.CharField(max_length=32)
+    is_read = models.BooleanField(default=False)
+    timestamp = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['-timestamp']
+
+    def __str__(self):
+        return f"{self.user}: {self.title}"
+
+
+class DeviceToken(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    device_type = models.CharField(max_length=32)
+    token = models.CharField(max_length=255)
+    platform = models.CharField(max_length=32)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.user} {self.platform}"

--- a/go-to-gym-platform/backend/core_api/notifications/serializers.py
+++ b/go-to-gym-platform/backend/core_api/notifications/serializers.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+from .models import Notification, DeviceToken
+
+
+class NotificationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Notification
+        fields = ['id', 'user', 'title', 'body', 'type', 'is_read', 'timestamp']
+        read_only_fields = ['id', 'timestamp']
+
+
+class DeviceTokenSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DeviceToken
+        fields = ['id', 'user', 'device_type', 'token', 'platform', 'created_at']
+        read_only_fields = ['id', 'created_at']

--- a/go-to-gym-platform/backend/core_api/notifications/tasks.py
+++ b/go-to-gym-platform/backend/core_api/notifications/tasks.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from django.core.mail import send_mail
+from django.template.loader import render_to_string
+from firebase_admin import messaging
+from celery import shared_task
+
+
+@shared_task
+def send_push_notification(token, title, body):
+    message = messaging.Message(
+        token=token,
+        notification=messaging.Notification(title=title, body=body),
+    )
+    messaging.send(message)
+
+
+@shared_task
+def send_email_notification(email, subject, body, template="generic_notification.html", context=None):
+    context = context or {"body": body, "title": subject}
+    html_message = render_to_string(f"notifications/emails/{template}", context)
+    send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [email], html_message=html_message)

--- a/go-to-gym-platform/backend/core_api/notifications/templates/emails/generic_notification.html
+++ b/go-to-gym-platform/backend/core_api/notifications/templates/emails/generic_notification.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title }}</title>
+    <style>
+        body {font-family: Arial, sans-serif; background: #f7f7f7; padding: 20px;}
+        .container {max-width: 600px; margin: auto; background: #ffffff; padding: 20px; border-radius: 4px;}
+        h2 {color: #333333;}
+        p {color: #555555;}
+        a.button {display: inline-block; margin-top: 20px; padding: 10px 15px; background: #007bff; color: #ffffff; text-decoration: none; border-radius: 4px;}
+    </style>
+</head>
+<body>
+<div class="container">
+    <h2>{{ title }}</h2>
+    <p>{{ body }}</p>
+    {% if action_url %}
+    <a href="{{ action_url }}" class="button">Ver más</a>
+    {% endif %}
+</div>
+</body>
+</html>

--- a/go-to-gym-platform/backend/core_api/notifications/templates/emails/motivational_notification.html
+++ b/go-to-gym-platform/backend/core_api/notifications/templates/emails/motivational_notification.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>¡Sigue entrenando!</title>
+    <style>
+        body {font-family: Arial, sans-serif; background:#fafafa; padding:20px;}
+        .container {max-width:600px; margin:auto; background:#ffffff; padding:20px; border-radius:4px; text-align:center;}
+        h2 {color:#2c3e50;}
+        p {color:#555555;}
+        a.button {display:inline-block; margin-top:20px; padding:10px 20px; background:#28a745; color:#fff; text-decoration:none; border-radius:4px;}
+    </style>
+</head>
+<body>
+<div class="container">
+    <h2>¡Buen trabajo, {{ user_name }}!</h2>
+    <p>{{ body }}</p>
+    {% if action_url %}
+    <a href="{{ action_url }}" class="button">Ir a la rutina</a>
+    {% endif %}
+</div>
+</body>
+</html>

--- a/go-to-gym-platform/backend/core_api/notifications/urls.py
+++ b/go-to-gym-platform/backend/core_api/notifications/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from .views import NotificationSendView, NotificationListView, DeviceTokenView
+
+urlpatterns = [
+    path('notifications/send/', NotificationSendView.as_view(), name='send-notification'),
+    path('notifications/', NotificationListView.as_view(), name='notification-list'),
+    path('device-token/', DeviceTokenView.as_view(), name='device-token'),
+]

--- a/go-to-gym-platform/backend/core_api/notifications/views.py
+++ b/go-to-gym-platform/backend/core_api/notifications/views.py
@@ -1,0 +1,52 @@
+from rest_framework import generics, permissions, status
+from rest_framework.response import Response
+from django.contrib.auth import get_user_model
+
+from .models import Notification, DeviceToken
+from .serializers import NotificationSerializer, DeviceTokenSerializer
+from .tasks import send_push_notification, send_email_notification
+
+
+class NotificationSendView(generics.CreateAPIView):
+    serializer_class = NotificationSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def create(self, request, *args, **kwargs):
+        user_id = request.data.get('user')
+        title = request.data.get('title')
+        body = request.data.get('body')
+        channel = request.data.get('channel', 'push')
+        template = request.data.get('template', 'generic_notification.html')
+
+        user_model = get_user_model()
+        try:
+            user = user_model.objects.get(id=user_id)
+        except user_model.DoesNotExist:
+            return Response({'detail': 'User not found'}, status=status.HTTP_404_NOT_FOUND)
+
+        notification = Notification.objects.create(user=user, title=title, body=body, type=request.data.get('type', 'generic'))
+        if channel == 'push':
+            tokens = DeviceToken.objects.filter(user=user)
+            for device in tokens:
+                send_push_notification.delay(device.token, title, body)
+        elif channel == 'email':
+            send_email_notification.delay(user.email, title, body, template)
+
+        serializer = self.get_serializer(notification)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class NotificationListView(generics.ListAPIView):
+    serializer_class = NotificationSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        return Notification.objects.filter(user=self.request.user)[:20]
+
+
+class DeviceTokenView(generics.CreateAPIView):
+    serializer_class = DeviceTokenSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)

--- a/go-to-gym-platform/frontend/webapp/components/NotificationBanner.js
+++ b/go-to-gym-platform/frontend/webapp/components/NotificationBanner.js
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+
+export default function NotificationBanner({ message }) {
+  const [visible, setVisible] = useState(!!message);
+
+  useEffect(() => {
+    setVisible(!!message);
+  }, [message]);
+
+  if (!visible || !message) return null;
+
+  const handleClose = () => setVisible(false);
+
+  return (
+    <div className="notification-banner">
+      <p>{message.body}</p>
+      <button onClick={handleClose}>Cerrar</button>
+    </div>
+  );
+}

--- a/go-to-gym-platform/frontend/webapp/firebase-config.js
+++ b/go-to-gym-platform/frontend/webapp/firebase-config.js
@@ -1,0 +1,12 @@
+import { initializeApp } from 'firebase/app';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export default app;

--- a/go-to-gym-platform/frontend/webapp/public/firebase-messaging-sw.js
+++ b/go-to-gym-platform/frontend/webapp/public/firebase-messaging-sw.js
@@ -1,0 +1,11 @@
+importScripts('https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/9.6.1/firebase-messaging-compat.js');
+
+firebase.initializeApp(self.firebaseConfig);
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage(function(payload) {
+  self.registration.showNotification(payload.notification.title, {
+    body: payload.notification.body,
+  });
+});

--- a/go-to-gym-platform/frontend/webapp/services/notifications.js
+++ b/go-to-gym-platform/frontend/webapp/services/notifications.js
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+export async function registerDeviceToken(token, authToken) {
+  return axios.post('/api/device-token/', { token }, {
+    headers: { Authorization: `Bearer ${authToken}` },
+  });
+}
+
+export async function fetchNotifications(authToken) {
+  const res = await axios.get('/api/notifications/', {
+    headers: { Authorization: `Bearer ${authToken}` },
+  });
+  return res.data;
+}

--- a/go-to-gym-platform/frontend/webapp/utils/registerFCM.js
+++ b/go-to-gym-platform/frontend/webapp/utils/registerFCM.js
@@ -1,0 +1,15 @@
+import { getMessaging, getToken } from 'firebase/messaging';
+import app from '../firebase-config';
+import { registerDeviceToken } from '../services/notifications';
+
+export async function registerFCM(authToken) {
+  try {
+    const messaging = getMessaging(app);
+    const token = await getToken(messaging, { vapidKey: process.env.NEXT_PUBLIC_FCM_VAPID });
+    if (token) {
+      await registerDeviceToken(token, authToken);
+    }
+  } catch (err) {
+    console.error('FCM registration failed', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add example email templates for notifications
- improve Celery task to render HTML templates
- allow selecting email template from API
- document templates in README

## Testing
- `python -m py_compile go-to-gym-platform/backend/core_api/notifications/tasks.py go-to-gym-platform/backend/core_api/notifications/views.py`


------
https://chatgpt.com/codex/tasks/task_e_6848c0d043948332992fdfd40add4c78