### PR TITLE
Implement password reset workflow

### DIFF
--- a/go-to-gym-platform/backend/core_api/auth/apps.py
+++ b/go-to-gym-platform/backend/core_api/auth/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AuthConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'core_api.auth'

--- a/go-to-gym-platform/backend/core_api/auth/models.py
+++ b/go-to-gym-platform/backend/core_api/auth/models.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from django.db import models
+from django.utils import timezone
+import uuid
+
+
+class PasswordResetToken(models.Model):
+    """Token para restablecer contraseña"""
+
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    token = models.UUIDField(default=uuid.uuid4, unique=True, editable=False)
+    is_used = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    expires_at = models.DateTimeField()
+
+    def save(self, *args, **kwargs):
+        if not self.expires_at:
+            self.expires_at = timezone.now() + timezone.timedelta(hours=24)
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return f"{self.user} - {self.token}"

--- a/go-to-gym-platform/backend/core_api/auth/serializers.py
+++ b/go-to-gym-platform/backend/core_api/auth/serializers.py
@@ -1,0 +1,22 @@
+from rest_framework import serializers
+
+
+class ForgotPasswordSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+
+
+class ResetPasswordSerializer(serializers.Serializer):
+    new_password = serializers.CharField(write_only=True)
+    confirm_password = serializers.CharField(write_only=True)
+
+    def validate_new_password(self, value):
+        if len(value) < 8 or not any(c.isupper() for c in value) or not any(c.isdigit() for c in value):
+            raise serializers.ValidationError(
+                'La contraseña debe tener al menos 8 caracteres, una mayúscula y un número'
+            )
+        return value
+
+    def validate(self, attrs):
+        if attrs['new_password'] != attrs['confirm_password']:
+            raise serializers.ValidationError({'confirm_password': 'Las contraseñas no coinciden'})
+        return attrs

--- a/go-to-gym-platform/backend/core_api/auth/templates/auth/forgot_password.html
+++ b/go-to-gym-platform/backend/core_api/auth/templates/auth/forgot_password.html
@@ -1,0 +1,8 @@
+<!-- Formulario para solicitar recuperación de contraseña -->
+<form method="post">
+    <!-- csrf token -->
+    <input type="email" name="email" placeholder="Email" required />
+    <button type="submit">Enviar enlace</button>
+</form>
+{% if error %}<p>{{ error }}</p>{% endif %}
+{% if message %}<p>{{ message }}</p>{% endif %}

--- a/go-to-gym-platform/backend/core_api/auth/templates/auth/reset_password.html
+++ b/go-to-gym-platform/backend/core_api/auth/templates/auth/reset_password.html
@@ -1,0 +1,12 @@
+<!-- Formulario para ingresar nueva contraseña -->
+{% if invalid %}
+<p>Este enlace ya no es válido</p>
+{% else %}
+<form method="post">
+    <!-- csrf token -->
+    <input type="password" name="new_password" placeholder="Nueva contraseña" required />
+    <input type="password" name="confirm_password" placeholder="Confirmar contraseña" required />
+    <button type="submit">Actualizar contraseña</button>
+</form>
+{% if errors %}<p>{{ errors }}</p>{% endif %}
+{% endif %}

--- a/go-to-gym-platform/backend/core_api/auth/templates/auth/reset_success.html
+++ b/go-to-gym-platform/backend/core_api/auth/templates/auth/reset_success.html
@@ -1,0 +1,2 @@
+<!-- Mensaje de confirmación de cambio de contraseña -->
+<p>Tu contraseña ha sido actualizada con éxito.</p>

--- a/go-to-gym-platform/backend/core_api/auth/templates/emails/password_reset_email.html
+++ b/go-to-gym-platform/backend/core_api/auth/templates/emails/password_reset_email.html
@@ -1,0 +1,4 @@
+<h1>Recupera tu contraseña en GoToGym</h1>
+<p>Haz clic en el siguiente enlace para restablecer tu contraseña:</p>
+<p><a href="{{ reset_link }}">{{ reset_link }}</a></p>
+<p>Si no solicitaste este cambio, ignora este correo.</p>

--- a/go-to-gym-platform/backend/core_api/auth/urls.py
+++ b/go-to-gym-platform/backend/core_api/auth/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from .views import ForgotPasswordView, ResetPasswordView, ResetPasswordSuccessView
+
+urlpatterns = [
+    path('auth/forgot-password/', ForgotPasswordView.as_view(), name='forgot-password'),
+    path('auth/reset-password/<uuid:token>/', ResetPasswordView.as_view(), name='reset-password'),
+    path('auth/reset-success/', ResetPasswordSuccessView.as_view(), name='password-reset-success'),
+]

--- a/go-to-gym-platform/backend/core_api/auth/views.py
+++ b/go-to-gym-platform/backend/core_api/auth/views.py
@@ -1,0 +1,75 @@
+from django.contrib.auth import get_user_model
+from django.contrib.sessions.models import Session
+from django.core.mail import send_mail
+from django.shortcuts import get_object_or_404, redirect, render
+from django.template.loader import render_to_string
+from django.utils import timezone
+from django.views import View
+
+from .models import PasswordResetToken
+from .serializers import ForgotPasswordSerializer, ResetPasswordSerializer
+
+
+class ForgotPasswordView(View):
+    """Solicita un correo de recuperación de contraseña"""
+
+    def get(self, request):
+        return render(request, 'auth/forgot_password.html')
+
+    def post(self, request):
+        serializer = ForgotPasswordSerializer(data=request.POST)
+        if serializer.is_valid():
+            User = get_user_model()
+            try:
+                user = User.objects.get(email=serializer.validated_data['email'])
+            except User.DoesNotExist:
+                return render(request, 'auth/forgot_password.html', {'error': 'No se encontró el usuario'})
+
+            token = PasswordResetToken.objects.create(user=user)
+            reset_link = f"https://gotogym.com/auth/reset-password/{token.token}/"
+            html_message = render_to_string(
+                'emails/password_reset_email.html', {'reset_link': reset_link}
+            )
+            send_mail(
+                'Recupera tu contraseña en GoToGym',
+                f'Visita {reset_link} para restablecer tu contraseña',
+                'support@gotogym.store',
+                [user.email],
+                html_message=html_message,
+            )
+            return render(request, 'auth/forgot_password.html', {'message': 'Revisa tu correo para continuar'})
+        return render(request, 'auth/forgot_password.html', {'errors': serializer.errors})
+
+
+class ResetPasswordView(View):
+    """Valida el token y actualiza la contraseña"""
+
+    def get(self, request, token):
+        token_obj = PasswordResetToken.objects.filter(token=token, is_used=False).first()
+        if not token_obj or token_obj.expires_at < timezone.now():
+            return render(request, 'auth/reset_password.html', {'invalid': True})
+        return render(request, 'auth/reset_password.html', {'token': token})
+
+    def post(self, request, token):
+        token_obj = get_object_or_404(PasswordResetToken, token=token, is_used=False)
+        if token_obj.expires_at < timezone.now():
+            return render(request, 'auth/reset_password.html', {'invalid': True})
+        serializer = ResetPasswordSerializer(data=request.POST)
+        if serializer.is_valid():
+            user = token_obj.user
+            user.set_password(serializer.validated_data['new_password'])
+            user.save()
+            token_obj.is_used = True
+            token_obj.save()
+            # invalidate sessions
+            for session in Session.objects.filter(expire_date__gte=timezone.now()):
+                data = session.get_decoded()
+                if str(user.pk) == str(data.get('_auth_user_id')):
+                    session.delete()
+            return redirect('password-reset-success')
+        return render(request, 'auth/reset_password.html', {'token': token, 'errors': serializer.errors})
+
+
+class ResetPasswordSuccessView(View):
+    def get(self, request):
+        return render(request, 'auth/reset_success.html')


### PR DESCRIPTION
## Summary
- add core_api auth app
- support password reset tokens and views
- include basic HTML templates for the workflow

## Testing
- `python -m py_compile go-to-gym-platform/backend/core_api/auth/*.py`
- `python go-to-gym-platform/backend/services/wellness_monitor/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6848d60ff4c483328cf29535ea4413be