### PR TITLE
Add comprehensive admin support

### DIFF
--- a/go-to-gym-platform/backend/services/wellness_monitor/monitor/admin.py
+++ b/go-to-gym-platform/backend/services/wellness_monitor/monitor/admin.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+
+from .models import HealthMetric
+
+@admin.register(HealthMetric)
+class HealthMetricAdmin(admin.ModelAdmin):
+    list_display = ("user", "metric_type", "value", "timestamp", "source")
+    search_fields = ("user__email",)
+    list_filter = ("metric_type", "source")

--- a/gotogym/auth/admin.py
+++ b/gotogym/auth/admin.py
@@ -1,0 +1,23 @@
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.utils.translation import gettext_lazy as _
+
+from .models import User
+
+@admin.register(User)
+class UserAdmin(BaseUserAdmin):
+    fieldsets = (
+        (None, {"fields": ("email", "password")}),
+        (_("Personal info"), {"fields": ("full_name", "accepted_terms", "terms_accepted_at", "terms_hash")}),
+        (_("Permissions"), {"fields": ("is_active", "is_staff", "is_superuser", "groups", "user_permissions")}),
+        (_("Important dates"), {"fields": ("last_login", "date_joined")}),
+    )
+    add_fieldsets = (
+        (None, {
+            "classes": ("wide",),
+            "fields": ("email", "full_name", "password1", "password2", "accepted_terms"),
+        }),
+    )
+    list_display = ("email", "full_name", "is_staff", "accepted_terms")
+    search_fields = ("email", "full_name")
+    ordering = ("email",)

--- a/gotogym/gotogym/admin.py
+++ b/gotogym/gotogym/admin.py
@@ -1,0 +1,5 @@
+from django.contrib import admin
+
+admin.site.site_header = "GoToGym Administración"
+admin.site.site_title = "GoToGym Admin"
+admin.site.index_title = "Panel de administración"

--- a/gotogym/products/admin.py
+++ b/gotogym/products/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from products.models import Product
+from products.models import Product, Category
 
 class ProductAdmin(admin.ModelAdmin):
     model = Product
@@ -17,3 +17,9 @@ class ProductAdmin(admin.ModelAdmin):
     ]
 
 admin.site.register(Product, ProductAdmin)
+
+
+@admin.register(Category)
+class CategoryAdmin(admin.ModelAdmin):
+    list_display = ("name", "description")
+    search_fields = ("name",)


### PR DESCRIPTION
## Summary
- register custom auth `User` model in admin
- tweak admin site titles
- expose `HealthMetric` via admin interface
- allow managing product categories

## Testing
- `pytest -q`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6848e937dc988332b9d4802dbb47214a